### PR TITLE
Make runnable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TEXS = $(patsubst %.md, %.tex, $(SRCS))
 book: e-maxx.pdf misc/imgfetch.sh
 
 e-maxx.pdf: e-maxx.tex
-	latexmk $<
+	latexmk -pdf $<
 
 e-maxx.tex: $(TEXS) misc/assemble.sh misc/template.tex
 	bash misc/assemble.sh > $@


### PR DESCRIPTION
`latexmk` tries to compile the tex files into a dvi file, which ends with problems with the png images.
At least it does so on my system.

This pull request explicitly tells `latexmk` to compile into a PDF, and also updates the submodule so that it has the newest fixes from e-maxx-eng.