### PR TITLE
Update imgfetch.sh to support macOS

### DIFF
--- a/misc/imgfetch.sh
+++ b/misc/imgfetch.sh
@@ -5,7 +5,7 @@ readonly IMG_PATH="$(dirname "$0")/../e-maxx-eng/static/img"
 mkdir -p "${IMG_PATH}"
 cd "${IMG_PATH}"
 
-grep -hroP 'https?://[^ ]*(png|jpe?g)' ../../src |
+grep -hroE 'https?://[^ ]*(png|jpe?g)' ../../src |
 while read url; do
     wget -nc "$url"
 done


### PR DESCRIPTION
The original was written assuming GNU grep, which is not the case on MacOS. The author suggested that making this change might resolve the incompatibility, which turned out to be the case.